### PR TITLE
Update PerfectoTestListener.groovy

### DIFF
--- a/Test Listeners/PerfectoTestListener.groovy
+++ b/Test Listeners/PerfectoTestListener.groovy
@@ -78,9 +78,7 @@ class PerfectoTestListener {
 			}else{
 				reportiumClient.testStop(TestResultFactory.createFailure(testCaseContext.getTestCaseStatus(), new Throwable(testCaseContext.getMessage())))
 			}
-
-		}
-		try{
+try{
 			MobileDriverFactory.closeDriver()
 		}catch(Exception a){}
 		try{
@@ -88,5 +86,7 @@ class PerfectoTestListener {
 				DriverFactory.getWebDriver().quit()
 			}}
 		catch(Exception e){}
+		}
+		
 	}
 }


### PR DESCRIPTION
If you want this behavior within the plug-in, then I suggest moving the driver clean-up code within this code block in order to avoid affecting other use cases where users want to do something themselves before quitting the driver.