### PR TITLE
Plugin update 2024

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 plugins {
   id 'java'
   id 'groovy'
-  id 'com.github.johnrengelman.shadow' version '6.1.0'
+  id 'com.gradleup.shadow' version '8.3.0'
   id "com.katalon.gradle-plugin" version "0.1.2"
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,6 @@ plugins {
 }
 
 repositories {
-  jcenter()
   mavenCentral()
 }
 


### PR DESCRIPTION
Changed Shadow version to 8.3 and Katalon plugin version to 0.1.2, removed deprecated mvn repo